### PR TITLE
Add selectable wallet provider

### DIFF
--- a/PhantomConnectExample/PhantomConnectExample/ContentView.swift
+++ b/PhantomConnectExample/PhantomConnectExample/ContentView.swift
@@ -29,7 +29,8 @@ struct ContentView: View {
                 PhantomConnect.configure(
                     appUrl: "https://example.com",
                     cluster: "devnet",
-                    redirectUrl: "example://"
+                    redirectUrl: "example://",
+                    walletProvider: .phantom
                 )
                 
             }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ You'll need to configure the framework to make sure you're pulling in the right 
 PhantomConnect.configure(
     appUrl: <YOUR_APP_URL>, // used for metadata (e.g. image shown in phantom dialog during deeplinking)
     cluster: <SOLANA_CLUSTER>, // `devnet`|`mainnet-beta`
-    redirectUrl: <YOUR_APP_URL_SCHEME> // reverse app domain url ensures uniqueness, but this can be what ever you define
+    redirectUrl: <YOUR_APP_URL_SCHEME>, // reverse app domain url ensures uniqueness, but this can be what ever you define
+    walletProvider: .phantom // `.solflare` and `.metamask` supported
 )
 ```
 

--- a/Sources/PhantomConnect/Models/WalletProvider.swift
+++ b/Sources/PhantomConnect/Models/WalletProvider.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public enum WalletProvider {
+    case phantom
+    case solflare
+    case metamask
+
+    var baseURL: String {
+        switch self {
+        case .phantom:
+            return "https://phantom.app/"
+        case .solflare:
+            return "https://solflare.com/"
+        case .metamask:
+            return "https://metamask.app.link/"
+        }
+    }
+
+    var prefix: String {
+        switch self {
+        case .phantom:
+            return "phantom"
+        case .solflare:
+            return "solflare"
+        case .metamask:
+            return "metamask"
+        }
+    }
+}

--- a/Sources/PhantomConnect/PhantomConnect.swift
+++ b/Sources/PhantomConnect/PhantomConnect.swift
@@ -24,11 +24,13 @@ public struct PhantomConnect {
     public static func configure(
         appUrl: String,
         cluster: String,
-        redirectUrl: String
+        redirectUrl: String,
+        walletProvider: WalletProvider = .phantom
     ) {
         PhantomConnectService.appUrl = appUrl
         PhantomConnectService.cluster = cluster
         PhantomConnectService.redirectUrl = redirectUrl
+        PhantomConnectService.walletProvider = walletProvider
     }
     
 }

--- a/Sources/PhantomConnect/Services/PhantomConnectService.swift
+++ b/Sources/PhantomConnect/Services/PhantomConnectService.swift
@@ -22,6 +22,7 @@ public class PhantomConnectService {
     static var appUrl: String?
     static var cluster: String?
     static var redirectUrl: String?
+    static var walletProvider: WalletProvider = .phantom
     
     // MARK: Internal Static Methods
     
@@ -48,10 +49,10 @@ public class PhantomConnectService {
         
         try checkConfiguration()
         
-        guard let url = UrlUtils.format("\(phantomBase)ul/\(version!)/connect", parameters: [
+        guard let url = UrlUtils.format("\(walletBase)ul/\(version!)/connect", parameters: [
             "app_url": PhantomConnectService.appUrl!,
             "dapp_encryption_public_key": Base58.encode(publicKey.bytes),
-            "redirect_link": "\(PhantomConnectService.redirectUrl!)phantom_connect",
+            "redirect_link": "\(PhantomConnectService.redirectUrl!)\(walletPrefix)_connect",
             "cluster": "\(PhantomConnectService.cluster!)"
         ]) else {
             throw PhantomConnectError.invalidUrl
@@ -82,9 +83,9 @@ public class PhantomConnectService {
             throw PhantomConnectError.invalidEncryptionPublicKey
         }
         
-        guard let url = UrlUtils.format("\(phantomBase)ul/\(version!)/disconnect", parameters: [
+        guard let url = UrlUtils.format("\(walletBase)ul/\(version!)/disconnect", parameters: [
             "dapp_encryption_public_key": encryptionPublicKey.base58EncodedString,
-            "redirect_link": "\(PhantomConnectService.redirectUrl!)phantom_disconnect",
+            "redirect_link": "\(PhantomConnectService.redirectUrl!)\(walletPrefix)_disconnect",
             "nonce": nonce,
             "payload": payload
         ]) else {
@@ -116,9 +117,9 @@ public class PhantomConnectService {
             throw PhantomConnectError.invalidEncryptionPublicKey
         }
         
-        guard let url = UrlUtils.format("\(phantomBase)ul/\(version!)/signAndSendTransaction", parameters: [
+        guard let url = UrlUtils.format("\(walletBase)ul/\(version!)/signAndSendTransaction", parameters: [
             "dapp_encryption_public_key": encryptionPublicKey.base58EncodedString,
-            "redirect_link": "\(PhantomConnectService.redirectUrl!)phantom_sign_and_send_transaction",
+            "redirect_link": "\(PhantomConnectService.redirectUrl!)\(walletPrefix)_sign_and_send_transaction",
             "nonce": nonce,
             "payload": payload
         ]) else {
@@ -164,7 +165,13 @@ public class PhantomConnectService {
     
     // MARK: Private Properties
     
-    private let phantomBase = "https://phantom.app/"
+    private var walletBase: String {
+        PhantomConnectService.walletProvider.baseURL
+    }
+
+    private var walletPrefix: String {
+        PhantomConnectService.walletProvider.prefix
+    }
     
     // MARK: Private Methods
     

--- a/Sources/PhantomConnect/Services/PhantomUrlHandler.swift
+++ b/Sources/PhantomConnect/Services/PhantomUrlHandler.swift
@@ -27,13 +27,14 @@ public class PhantomUrlHandler {
             return false
         }
         
+        let prefix = PhantomConnectService.walletProvider.prefix
         let slugs = [
-            "phantom_connect",
-            "phantom_disconnect",
-            "phantom_sign_transaction",
-            "phantom_sign_all_transactions",
-            "phantom_sign_and_send_transaction",
-            "phantom_sign_message"
+            "\(prefix)_connect",
+            "\(prefix)_disconnect",
+            "\(prefix)_sign_transaction",
+            "\(prefix)_sign_all_transactions",
+            "\(prefix)_sign_and_send_transaction",
+            "\(prefix)_sign_message"
         ]
         
         return slugs.contains(where: { $0 == components.host ?? ""})
@@ -70,8 +71,10 @@ public class PhantomUrlHandler {
             
         }
         
+        let prefix = PhantomConnectService.walletProvider.prefix
+
         switch host {
-            case "phantom_connect":
+            case "\(prefix)_connect":
                 
                 guard let phantomEncryptionPublicKey = PublicKey(string: params["phantom_encryption_public_key"] as? String ?? ""),
                       let dappSecretKey = dappSecretKey,
@@ -105,12 +108,12 @@ public class PhantomUrlHandler {
                     error: error
                 )
                 
-            case "phantom_disconnect":
+            case "\(prefix)_disconnect":
                 return .disconnect(
                     error: error
                 )
                 
-            case "phantom_sign_and_send_transaction":
+            case "\(prefix)_sign_and_send_transaction":
                     
                 guard let data = params["data"] as? String,
                       let nonce = params["nonce"] as? String,

--- a/Tests/PhantomConnectTests/PhantomConnectTests.swift
+++ b/Tests/PhantomConnectTests/PhantomConnectTests.swift
@@ -13,6 +13,12 @@ final class PhantomConnectTests: XCTestCase {
     func testConfiguration() throws {
             
         PhantomConnect.configure(appUrl: "url", cluster: "cluster", redirectUrl: "redirect")
+
+        XCTAssertEqual(PhantomConnectService.walletProvider, .phantom)
+
+        PhantomConnect.configure(appUrl: "url", cluster: "cluster", redirectUrl: "redirect", walletProvider: .solflare)
+
+        XCTAssertEqual(PhantomConnectService.walletProvider, .solflare)
         
         XCTAssertEqual(PhantomConnectService.appUrl, "url")
         XCTAssertEqual(PhantomConnectService.cluster, "cluster")

--- a/Tests/PhantomConnectTests/PhantomUrlHandlerTests.swift
+++ b/Tests/PhantomConnectTests/PhantomUrlHandlerTests.swift
@@ -11,10 +11,13 @@ import XCTest
 class PhantomUrlHandlerTests: XCTestCase {
     
     func testCanHandle() throws {
-        
-        let connect = URL(string: "url.scheme://phantom_connect")!
-        let disconnect = URL(string: "url.scheme://phantom_disconnect")!
-        let singAndSendTransaction = URL(string: "url.scheme://phantom_sign_and_send_transaction")!
+
+        PhantomConnect.configure(appUrl: "url", cluster: "cluster", redirectUrl: "redirect")
+
+        let prefix = PhantomConnectService.walletProvider.prefix
+        let connect = URL(string: "url.scheme://\(prefix)_connect")!
+        let disconnect = URL(string: "url.scheme://\(prefix)_disconnect")!
+        let singAndSendTransaction = URL(string: "url.scheme://\(prefix)_sign_and_send_transaction")!
         
         let unknown = URL(string: "url.scheme://unknown")!
         


### PR DESCRIPTION
## Summary
- add `WalletProvider` enum with Phantom, Solflare and MetaMask options
- allow configuration of wallet provider (default Phantom)
- generate deeplinks according to selected provider
- update README and example app
- update unit tests

## Testing
- `swift test` *(fails: no such module 'Accelerate.vecLib')*

------
https://chatgpt.com/codex/tasks/task_e_6848fefc808c83318cbb385a23d0cb6e